### PR TITLE
Removed suitesetup/teardown from Allure results

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ To enable this listener in a project using the 'standard HSAC maven setup':
 * set the maven property `extraFailsafeListeners` to `nl.hsac.fitnesse.junit.allure.JUnitAllureFrameworkListener`.
 
 The listener creates data for Allure reporting in `target/allure-results`, to get an actual report you still need to
-generate one based on these results. 
+generate one based on these results.
+
+* If you wish to ignore SuiteSetUp and SuiteTearDown test pages in Allure, this can be achieved by setting system property skipSpecialPagesInAllure to true (`skipSpecialPagesInAllure=true`)
 
 ## Generating Allure Report
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <fitnesse.version>20161106</fitnesse.version>
-        <hsac.fixtures.version>2.12.4</hsac.fixtures.version>
+        <fitnesse.version>20190421</fitnesse.version>
+        <hsac.fixtures.version>4.4.0</hsac.fixtures.version>
         <allure.version>1.5.4</allure.version>
     </properties>
 
@@ -74,6 +74,7 @@
             <artifactId>allure-java-adaptor-api</artifactId>
             <version>${allure.version}</version>
         </dependency>
+
     </dependencies>
 
     <build>
@@ -83,8 +84,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>true</showDeprecation>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.hsac</groupId>
     <artifactId>allure-fitnesse-listener</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <url>https://github.com/fhoeben/allure-fitnesse-listener</url>
     <name>Allure jUnit Listener for FitNesse</name>
     <description>jUnit Listener to incorporate FitNesse results in Allure</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.hsac</groupId>
     <artifactId>allure-fitnesse-listener</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <url>https://github.com/fhoeben/allure-fitnesse-listener</url>
     <name>Allure jUnit Listener for FitNesse</name>
     <description>jUnit Listener to incorporate FitNesse results in Allure</description>

--- a/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
@@ -64,12 +64,11 @@ public class JUnitAllureFrameworkListener extends RunListener {
         hostLabel.setValue(hostName);
     }
 
-    private boolean isSpecialPage(String pageName) {
+    public boolean isSpecialPage(String pageName) {
         return pageName.matches(".*(\\.SuiteSetUp|\\.SetUp|\\.TearDown|\\.SuiteTearDown)$");
     }
 
     private void testSuiteStarted(Description description) {
-        if (!isSpecialPage(description.getClassName())) {
             String uid = this.generateSuiteUid(description.getDisplayName());
             String suiteName = description.getClassName();
 
@@ -79,10 +78,9 @@ public class JUnitAllureFrameworkListener extends RunListener {
             event.withLabels(AllureModelUtils.createTestFrameworkLabel("FitNesse"));
             getAllure().fire(event);
         }
-    }
 
     public void testStarted(Description description) {
-        if (!isSpecialPage(description.getClassName())) {
+        if (!isSpecialPage(description.getMethodName())) {
             FitNessePageAnnotation pageAnn = description.getAnnotation(FitNessePageAnnotation.class);
             if (pageAnn != null) {
                 TestCaseStartedEvent event = new TestCaseStartedEvent(this.getSuiteUid(description), description.getMethodName());
@@ -99,7 +97,7 @@ public class JUnitAllureFrameworkListener extends RunListener {
     }
     public void testFailure(Failure failure) {
         Description description = failure.getDescription();
-        if (!isSpecialPage(description.getClassName())) {
+        if (!isSpecialPage(description.getMethodName())) {
             if (description.isTest()) {
                 Throwable exception = failure.getException();
                 List<Pattern> patterns = new ArrayList<>();
@@ -123,7 +121,7 @@ public class JUnitAllureFrameworkListener extends RunListener {
     }
 
     public void testFinished(Description description) {
-        if (!isSpecialPage(description.getClassName())) {
+        if (!isSpecialPage(description.getMethodName())) {
             String methodName = description.getMethodName();
             makeAttachment(fitnesseResult(methodName).getBytes(), "FitNesse Result page", "text/html");
             getAllure().fire(new TestCaseFinishedEvent());

--- a/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
@@ -64,7 +64,7 @@ public class JUnitAllureFrameworkListener extends RunListener {
         hostLabel.setValue(hostName);
     }
 
-    public boolean isSpecialPage(String pageName) {
+    private boolean isSpecialPage(String pageName) {
         return pageName.matches(".*(\\.SuiteSetUp|\\.SetUp|\\.TearDown|\\.SuiteTearDown)$");
     }
 

--- a/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/allure/JUnitAllureFrameworkListener.java
@@ -46,6 +46,7 @@ public class JUnitAllureFrameworkListener extends RunListener {
     private static final String PAGESOURCE_EXT = "html";
     private static final Pattern SCREENSHOT_PATTERN = Pattern.compile("href=\"([^\"]*." + SCREENSHOT_EXT + ")\"");
     private static final Pattern PAGESOURCE_PATTERN = Pattern.compile("href=\"([^\"]*." + PAGESOURCE_EXT + ")\"");
+    private static final Pattern SPECIAL_PAGE_PATTERN = Pattern.compile(".*(\\.SuiteSetUp|\\.SuiteTearDown)$");
     private final Environment hsacEnvironment = Environment.getInstance();
     private final HashMap<String, String> suites;
     private final Label hostLabel;
@@ -291,10 +292,6 @@ public class JUnitAllureFrameworkListener extends RunListener {
     }
 
     private boolean reportTestPage(String pageName) {
-        if (!skipSpecialPages) {
-            return true;
-        } else {
-            return !pageName.matches(".*(\\.SuiteSetUp|\\.SuiteTearDown)$");
-        }
+        return !skipSpecialPages || !SPECIAL_PAGE_PATTERN.matcher(pageName).matches();
     }
 }


### PR DESCRIPTION
SuiteSetup/Teardowns now clutter overview of testcases, while they aren't really testcases.